### PR TITLE
Modify dataloader for compatibility with legacy code

### DIFF
--- a/dataloader/base_dataloader.py
+++ b/dataloader/base_dataloader.py
@@ -48,17 +48,17 @@ class BaseDataLoader(ABC):
         pass
 
     @abstractmethod
-    def get_image_data(self, index: int) -> Tuple[np.ndarray, Optional[np.ndarray], np.ndarray]:
+    def get_image_data(self, index: int) -> Tuple[str, Optional[str], np.ndarray]:
         """
-        Get the RGB image, depth map, and pose at the specified index.
+        Get the RGB image path, depth map path, and pose at the specified index.
         
         Args:
             index (int): Index of the image.
         
         Returns:
             Tuple containing:
-            - RGB image (np.ndarray)
-            - Optional depth map (np.ndarray)
+            - RGB image path (str)
+            - Optional depth map (str)
             - Pose (np.ndarray)
         """
         pass

--- a/dataloader/synthetic_dataloader.py
+++ b/dataloader/synthetic_dataloader.py
@@ -86,13 +86,9 @@ class SynthDataloader(BaseDataLoader):
     def _get_environment_indices(self) -> Tuple[int, ...]:
         return [i for i in range(len(self._depth_images_paths)) if i not in self.evaluation_indices]
 
-    def get_image_data(self, index: int) -> Tuple[np.ndarray, Optional[np.ndarray], np.ndarray]:
-        cur_rgb_image = np.asarray(imageio.imread(self._rgb_images_paths[index]))
-        cur_depth_image = np.load(self._depth_images_paths[index])
+    def get_image_data(self, index: int):
         cur_pose = self._poses[index]
-
-        print(cur_rgb_image.shape, cur_depth_image.shape, cur_pose.shape)
-        return cur_rgb_image, cur_depth_image, cur_pose
+        return self._rgb_images_paths[index], self._depth_images_paths[index], cur_pose
 
     def get_pointcloud(self, bounding_box: Optional[Dict[str, Tuple[float, float]]] = None) -> o3d.geometry.PointCloud:
         if bounding_box is not None:

--- a/synth_dataloader_trial.py
+++ b/synth_dataloader_trial.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import open3d as o3d
 import numpy as np
 from utils import depth_utils
+import imageio
 
 def main(args):
     dataloader = SynthDataloader(
@@ -13,7 +14,9 @@ def main(args):
         map_pointcloud_cache_path=args.map_pcd_cache_path
     )
 
-    rgb, depth, pose = dataloader.get_image_data(0)
+    rgb_path, depth_path, pose = dataloader.get_image_data(0)
+    rgb = np.asarray(imageio.imread(rgb_path))
+    depth = np.load(depth_path)
 
     pcd = dataloader.get_visible_pointcloud(pose, 100, 0.05, 20)
 
@@ -24,7 +27,7 @@ def main(args):
     # o3d.visualization.draw_geometries([pcd, dataloader.get_pointcloud()])
 
     # in actual position (not in camera frame)
-    o3d.visualization.draw_geometries([depth_utils.transform_pointcloud(pcd, pose), dataloader.get_pointcloud(), depth_utils.transform_pointcloud(reformed_pcd, pose)])
+    # o3d.visualization.draw_geometries([depth_utils.transform_pointcloud(pcd, pose), dataloader.get_pointcloud(), depth_utils.transform_pointcloud(reformed_pcd, pose)])
 
 
 


### PR DESCRIPTION
@sarthakchittawar take a look at this -> I've changed the base_dataloader. About 2-3 minutes of changes on your parts.

Images are loaded using `PIL.Image.fromarray(image_source)` and even before that using `image_source, image = gd_load_image(image_path)`

Further, depth images must be loaded using `depth_image = np.load(depth_image_path)`
